### PR TITLE
fix: remove binary option which is unsupported in pg<14

### DIFF
--- a/pg_replicate/src/clients/postgres.rs
+++ b/pg_replicate/src/clients/postgres.rs
@@ -423,7 +423,7 @@ impl ReplicationClient {
         start_lsn: PgLsn,
     ) -> Result<LogicalReplicationStream, ReplicationClientError> {
         let options = format!(
-            r#"("proto_version" '1', "publication_names" {}, "binary")"#,
+            r#"("proto_version" '1', "publication_names" {})"#,
             quote_literal(publication)
         );
 


### PR DESCRIPTION
binary parameter in [postgres logical replication protocol](https://www.postgresql.org/docs/current/protocol-logical-replication.html) is supported from pg@14 and later.

> Boolean option to use binary transfer mode. Binary mode is faster than the text mode but slightly less robust.

This fix is to build and test a version without it for earlier pg versions like pg@12 and pg13