### PR TITLE
Revert "fix: remove binary option which is unsupported in pg<14"

### DIFF
--- a/pg_replicate/src/clients/postgres.rs
+++ b/pg_replicate/src/clients/postgres.rs
@@ -423,7 +423,7 @@ impl ReplicationClient {
         start_lsn: PgLsn,
     ) -> Result<LogicalReplicationStream, ReplicationClientError> {
         let options = format!(
-            r#"("proto_version" '1', "publication_names" {})"#,
+            r#"("proto_version" '1', "publication_names" {}, "binary")"#,
             quote_literal(publication)
         );
 


### PR DESCRIPTION
Reverts dejii/pg_replicate#1 because the current implementation is broken.

Removing the binary parameter is not sufficient, support for converting from text format into a `Cell` also needs to be added in the `CdcEventConverter::from_tuple_data` method.